### PR TITLE
fix: Mark Arrays as `isscimlstructure`

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -16,4 +16,4 @@ canonicalize(::Constants, p::Array) = nothing, nothing, nothing
 canonicalize(::Caches, p::Array) = nothing, nothing, nothing
 canonicalize(::Discrete, p::Array) = nothing, nothing, nothing
 
-isscimlstructure(::AbstractVecOrMat) = true
+isscimlstructure(::Array) = true

--- a/src/array.jl
+++ b/src/array.jl
@@ -15,3 +15,5 @@ canonicalize(::Tunable, p::Array) = vec(p), ArrayRepack(size(p)), true
 canonicalize(::Constants, p::Array) = nothing, nothing, nothing
 canonicalize(::Caches, p::Array) = nothing, nothing, nothing
 canonicalize(::Discrete, p::Array) = nothing, nothing, nothing
+
+isscimlstructure(::AbstractVecOrMat) = true


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Arrays should be trivially SciMLStructures. Can we mark `AbstractArrays`? The risk being that a number of invalid types (such as solution objects) would report incorrect values, but the current implementation ignores all special array types.

Add any other context about the problem here.
