### PR TITLE
Expand `Array` interface definition to `AbstractArray`

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -12,7 +12,7 @@ function (f::ArrayRepack)(A)
     reshape(convert(f.type, A), f.sz)
 end
 
-canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(size(p), typeof(A)), true
+canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(size(p), typeof(p)), true
 canonicalize(::Constants, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Caches, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Discrete, p::AbstractArray) = nothing, nothing, nothing

--- a/src/array.jl
+++ b/src/array.jl
@@ -3,20 +3,15 @@ hasportion(::Constants, ::AbstractArray) = false
 hasportion(::Caches, ::AbstractArray) = false
 hasportion(::Discrete, ::AbstractArray) = false
 
-struct ArrayRepack{T, Ty}
+struct ArrayRepack{T}
     sz::T
-    type::Ty
 end
 function (f::ArrayRepack)(A)
     @assert length(A) == prod(f.sz)
-    reshape(convert(f.type, A), f.sz)
+    reshape(A, f.sz)
 end
 
-function canonicalize(::Tunable, p::AbstractArray)
-    arr = collect(p)
-    vec(arr), ArrayRepack(size(p), typeof(p)), true
-end
-canonicalize(::Tunable, p::Array) = vec(p), ArrayRepack(size(p), typeof(p)), true
+canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(size(p)), true
 canonicalize(::Constants, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Caches, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Discrete, p::AbstractArray) = nothing, nothing, nothing

--- a/src/array.jl
+++ b/src/array.jl
@@ -3,15 +3,16 @@ hasportion(::Constants, ::AbstractArray) = false
 hasportion(::Caches, ::AbstractArray) = false
 hasportion(::Discrete, ::AbstractArray) = false
 
-struct ArrayRepack{T}
+struct ArrayRepack{T, Ty}
     sz::T
+    type::Ty
 end
 function (f::ArrayRepack)(A)
     @assert length(A) == prod(f.sz)
-    reshape(A, f.sz)
+    reshape(convert(f.type, A), f.sz)
 end
 
-canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(size(p)), true
+canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(size(p), typeof(A)), true
 canonicalize(::Constants, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Caches, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Discrete, p::AbstractArray) = nothing, nothing, nothing

--- a/src/array.jl
+++ b/src/array.jl
@@ -3,15 +3,20 @@ hasportion(::Constants, ::AbstractArray) = false
 hasportion(::Caches, ::AbstractArray) = false
 hasportion(::Discrete, ::AbstractArray) = false
 
-struct ArrayRepack{T}
+struct ArrayRepack{T, Ty}
     sz::T
+    type::Ty
 end
 function (f::ArrayRepack)(A)
     @assert length(A) == prod(f.sz)
-    reshape(A, f.sz)
+    reshape(convert(f.type, A), f.sz)
 end
 
-canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(size(p)), true
+function canonicalize(::Tunable, p::AbstractArray)
+    arr = collect(p)
+    vec(arr), ArrayRepack(size(p), typeof(p)), true
+end
+canonicalize(::Tunable, p::Array) = vec(p), ArrayRepack(size(p), typeof(p)), true
 canonicalize(::Constants, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Caches, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Discrete, p::AbstractArray) = nothing, nothing, nothing

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,7 +1,7 @@
-hasportion(::Tunable, ::Array) = true
-hasportion(::Constants, ::Array) = false
-hasportion(::Caches, ::Array) = false
-hasportion(::Discrete, ::Array) = false
+hasportion(::Tunable, ::AbstractArray) = true
+hasportion(::Constants, ::AbstractArray) = false
+hasportion(::Caches, ::AbstractArray) = false
+hasportion(::Discrete, ::AbstractArray) = false
 
 struct ArrayRepack{T}
     sz::T
@@ -11,9 +11,9 @@ function (f::ArrayRepack)(A)
     reshape(A, f.sz)
 end
 
-canonicalize(::Tunable, p::Array) = vec(p), ArrayRepack(size(p)), true
-canonicalize(::Constants, p::Array) = nothing, nothing, nothing
-canonicalize(::Caches, p::Array) = nothing, nothing, nothing
-canonicalize(::Discrete, p::Array) = nothing, nothing, nothing
+canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(size(p)), true
+canonicalize(::Constants, p::AbstractArray) = nothing, nothing, nothing
+canonicalize(::Caches, p::AbstractArray) = nothing, nothing, nothing
+canonicalize(::Discrete, p::AbstractArray) = nothing, nothing, nothing
 
-isscimlstructure(::Array) = true
+isscimlstructure(::AbstractArray) = true


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Currently SciMLStructures only defines its interface for `Array`s, but SciML makes use of various array types in its ecosystem. This PR expands that interface to `AbstractArray`. Important note here is that it actually materializes arrays, and assumes a method for `convert(T, arr)` per https://github.com/SciML/SciMLSensitivity.jl/pull/1057#issuecomment-2136764505

Add any other context about the problem here.
It is hard to test this generally, given that several array types may not support `convert` trivially.

```julia
julia> voa = VectorOfArray([rand(3)])
VectorOfArray{Float64,2}:
1-element Vector{Vector{Float64}}:
 [0.6018091617438924, 0.09932743885100326, 0.04452835123514798]

julia> convert(typeof(voa), [rand(3)])
ERROR: MethodError: Cannot `convert` an object of type Vector{Vector{Float64}} to an object of type VectorOfArray{Float64, 2, Vector{Vector{Float64}}}

Closest candidates are:
  convert(::Type{T}, ::T) where T
   @ Base Base.jl:84
  (::Type{VectorOfArray{T, N, A}} where {T, N, A})(::Any)
   @ RecursiveArrayTools ~/.julia/packages/RecursiveArrayTools/Z5iA5/src/vector_of_array.jl:39

Stacktrace:
 [1] top-level scope
   @ REPL[14]:1
```

ComponentArrays works better:

```julia
julia> cv = ComponentVector((x = rand(3), y = rand(3)))
ComponentVector{Float64}(x = [0.41846227575172246, 0.8810447271593488, 0.40581523710702416], y = [0.8329323692529603, 0.5688265966983299, 0.10744266774852296])

julia> convert(typeof(cv), rand(6))
ComponentVector{Float64}(x = [0.9555818255344598, 0.8857837397461067, 0.05538714669215161], y = [0.7689322127947471, 0.7902838116271699, 0.6846241786883972])
```

cc @ChrisRackauckas 