### PR TITLE
Check for existing constructor when dealing with Arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,10 @@ authors = ["SciML"]
 version = "1.2.0"
 
 [deps]
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 
 [compat]
+ArrayInterface = "7.10"
 Aqua = "0.8"
 SafeTestsets = "0.1"
 Test = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "1.2.0"
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 
 [compat]
-ArrayInterface = "7.10"
+ArrayInterface = "7.11"
 Aqua = "0.8"
 SafeTestsets = "0.1"
 Test = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLStructures"
 uuid = "53ae85a6-f571-4167-b2af-e1d143709226"
 authors = ["SciML"]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 

--- a/src/SciMLStructures.jl
+++ b/src/SciMLStructures.jl
@@ -1,5 +1,7 @@
 module SciMLStructures
 
+using ArrayInterface: has_trivial_array_constructor
+
 include("interface.jl")
 include("array.jl")
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -12,7 +12,7 @@ function (f::ArrayRepack)(A)
     reshape(convert(f.type, A), f.sz)
 end
 
-canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(size(p), typeof(A)), true
+canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(size(p), typeof(p)), true
 canonicalize(::Constants, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Caches, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Discrete, p::AbstractArray) = nothing, nothing, nothing

--- a/src/array.jl
+++ b/src/array.jl
@@ -3,20 +3,15 @@ hasportion(::Constants, ::AbstractArray) = false
 hasportion(::Caches, ::AbstractArray) = false
 hasportion(::Discrete, ::AbstractArray) = false
 
-struct ArrayRepack{T, Ty}
+struct ArrayRepack{T}
     sz::T
-    type::Ty
 end
 function (f::ArrayRepack)(A)
     @assert length(A) == prod(f.sz)
-    reshape(convert(f.type, A), f.sz)
+    reshape(A, f.sz)
 end
 
-function canonicalize(::Tunable, p::AbstractArray)
-    arr = collect(p)
-    vec(arr), ArrayRepack(size(p), typeof(p)), true
-end
-canonicalize(::Tunable, p::Array) = vec(p), ArrayRepack(size(p), typeof(p)), true
+canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(size(p)), true
 canonicalize(::Constants, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Caches, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Discrete, p::AbstractArray) = nothing, nothing, nothing

--- a/src/array.jl
+++ b/src/array.jl
@@ -12,7 +12,7 @@ function (f::ArrayRepack)(A)
     A_ = if has_trivial_array_contstructor(f.type, A)
         convert(f.type, A)
     else
-        error("The original type does not support the SciMLStructures interface via the AbstractArray `repack` rules. No method exists to take in a regular array and construct the parent type back. Please define the SciMLStructures interface for this type.")
+        error("The original type $(typeof(f.type)) does not support the SciMLStructures interface via the AbstractArray `repack` rules. No method exists to take in a regular array and construct the parent type back. Please define the SciMLStructures interface for this type.")
     end
     reshape(A_, f.sz)
 end

--- a/src/array.jl
+++ b/src/array.jl
@@ -3,15 +3,16 @@ hasportion(::Constants, ::AbstractArray) = false
 hasportion(::Caches, ::AbstractArray) = false
 hasportion(::Discrete, ::AbstractArray) = false
 
-struct ArrayRepack{T}
+struct ArrayRepack{T, Ty}
     sz::T
+    type::Ty
 end
 function (f::ArrayRepack)(A)
     @assert length(A) == prod(f.sz)
-    reshape(A, f.sz)
+    reshape(convert(f.type, A), f.sz)
 end
 
-canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(size(p)), true
+canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(size(p), typeof(A)), true
 canonicalize(::Constants, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Caches, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Discrete, p::AbstractArray) = nothing, nothing, nothing

--- a/src/array.jl
+++ b/src/array.jl
@@ -9,7 +9,7 @@ struct ArrayRepack{T, Ty}
 end
 function (f::ArrayRepack)(A)
     @assert length(A) == prod(f.sz)
-    A_ = if has_trivial_array_contstructor(f.type, A)
+    A_ = if has_trivial_array_constructor(f.type, A)
         convert(f.type, A)
     else
         error("The original type $(typeof(f.type)) does not support the SciMLStructures interface via the AbstractArray `repack` rules. No method exists to take in a regular array and construct the parent type back. Please define the SciMLStructures interface for this type.")

--- a/src/array.jl
+++ b/src/array.jl
@@ -3,15 +3,20 @@ hasportion(::Constants, ::AbstractArray) = false
 hasportion(::Caches, ::AbstractArray) = false
 hasportion(::Discrete, ::AbstractArray) = false
 
-struct ArrayRepack{T}
+struct ArrayRepack{T, Ty}
     sz::T
+    type::Ty
 end
 function (f::ArrayRepack)(A)
     @assert length(A) == prod(f.sz)
-    reshape(A, f.sz)
+    reshape(convert(f.type, A), f.sz)
 end
 
-canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(size(p)), true
+function canonicalize(::Tunable, p::AbstractArray)
+    arr = collect(p)
+    vec(arr), ArrayRepack(size(p), typeof(p)), true
+end
+canonicalize(::Tunable, p::Array) = vec(p), ArrayRepack(size(p), typeof(p)), true
 canonicalize(::Constants, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Caches, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Discrete, p::AbstractArray) = nothing, nothing, nothing

--- a/src/array.jl
+++ b/src/array.jl
@@ -12,7 +12,7 @@ function (f::ArrayRepack)(A)
     A_ = if has_trivial_array_contstructor(f.type, A)
         convert(f.type, A)
     else
-        error("Cannot convert to original type")
+        error("The original type does not support the SciMLStructures interface via the AbstractArray `repack` rules. No method exists to take in a regular array and construct the parent type back. Please define the SciMLStructures interface for this type.")
     end
     reshape(A_, f.sz)
 end

--- a/src/array.jl
+++ b/src/array.jl
@@ -9,7 +9,12 @@ struct ArrayRepack{T, Ty}
 end
 function (f::ArrayRepack)(A)
     @assert length(A) == prod(f.sz)
-    reshape(convert(f.type, A), f.sz)
+    A_ = if has_trivial_array_contstructor(f.type, A)
+        convert(f.type, A)
+    else
+        error("Cannot convert to original type")
+    end
+    reshape(A_, f.sz)
 end
 
 canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(size(p), typeof(p)), true

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,7 +1,7 @@
-hasportion(::Tunable, ::Array) = true
-hasportion(::Constants, ::Array) = false
-hasportion(::Caches, ::Array) = false
-hasportion(::Discrete, ::Array) = false
+hasportion(::Tunable, ::AbstractArray) = true
+hasportion(::Constants, ::AbstractArray) = false
+hasportion(::Caches, ::AbstractArray) = false
+hasportion(::Discrete, ::AbstractArray) = false
 
 struct ArrayRepack{T}
     sz::T
@@ -11,9 +11,9 @@ function (f::ArrayRepack)(A)
     reshape(A, f.sz)
 end
 
-canonicalize(::Tunable, p::Array) = vec(p), ArrayRepack(size(p)), true
-canonicalize(::Constants, p::Array) = nothing, nothing, nothing
-canonicalize(::Caches, p::Array) = nothing, nothing, nothing
-canonicalize(::Discrete, p::Array) = nothing, nothing, nothing
+canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(size(p)), true
+canonicalize(::Constants, p::AbstractArray) = nothing, nothing, nothing
+canonicalize(::Caches, p::AbstractArray) = nothing, nothing, nothing
+canonicalize(::Discrete, p::AbstractArray) = nothing, nothing, nothing
 
-isscimlstructure(::Array) = true
+isscimlstructure(::AbstractArray) = true

--- a/src/array.jl
+++ b/src/array.jl
@@ -24,7 +24,7 @@ canonicalize(::Discrete, p::AbstractArray) = nothing, nothing, nothing
 
 isscimlstructure(::AbstractArray) = true
 
-function SciMLStructures.replace(::SciMLStructures.Tunable, arr::AbstractArray, new_arr::AbstractArray)
+function SciMLStructures.replace(
+        ::SciMLStructures.Tunable, arr::AbstractArray, new_arr::AbstractArray)
     reshape(new_arr, size(arr))
 end
-


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

While we want to support AbstractArrays for a few limited cases, it is important to guard against failure modes. This uses a new interface from ArrayInterface `has_trivial_array_constructor` which checks whether an applicable `convert` method exists and can be used to repack the gradient vector back into its parent parameter type.

Add any other context about the problem here.
