### PR TITLE
Add `replace(::Array)`

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -17,3 +17,7 @@ canonicalize(::Caches, p::Array) = nothing, nothing, nothing
 canonicalize(::Discrete, p::Array) = nothing, nothing, nothing
 
 isscimlstructure(::Array) = true
+
+function SciMLStructures.replace(::SciMLStructures.Tunable, arr::AbstractArray, new_arr::AbstractArray)
+    reshape(new_arr, size(arr))
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

The array interface is not completely defined. Is it alright for us to alias the incoming array in this case? Replace sounds like we should be returning the parent array type, but that is harder to do correctly. Maybe we can add a separate dispatch that takes an unbounded `arg` which checks `ArrayInterface.has_trivial_array_constructor` first. 

Add any other context about the problem here.
