### PR TITLE
feat: allow `NamedTuple` as SciMLStructure

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,8 @@ Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 
 [compat]
 Aqua = "0.8"
+DataStructures = "0.18"
+Functors = "0.4"
 SafeTestsets = "0.1"
 Test = "1.10"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,8 @@ authors = ["SciML"]
 version = "1.2.0"
 
 [deps]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 
 [compat]
 Aqua = "0.8"

--- a/src/SciMLStructures.jl
+++ b/src/SciMLStructures.jl
@@ -1,7 +1,11 @@
 module SciMLStructures
 
+import Functors
+using DataStructures: OrderedDict
+
 include("interface.jl")
 include("array.jl")
+include("namedtuple.jl")
 
 # public isscimlstructure, ismutablescimlstructure, hasportion, canonicalize,
 #        replace, replace!, Tunable, Constants, Caches, Discrete

--- a/src/namedtuple.jl
+++ b/src/namedtuple.jl
@@ -20,12 +20,7 @@ function (re::NTRepack)(x::AbstractVector)
 end
 
 function canonicalize(::Tunable, nt::NamedTuple)
-    cache = OrderedDict()
-    Functors.fmap(nt) do v
-        cache[objectid(v)] = vec(v)
-        v
-    end
-    reduce(vcat, values(cache)), NTRepack(nt), false
+    nt, NTRepack(nt), false
 end
 
 canonicalize(::Constants, p::NamedTuple) = nothing, nothing, nothing

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -1,0 +1,7 @@
+@testset "NamedTuple" begin
+    test_p = (layer_1 = (weight = rand(Float32, 2, 2), bias = rand(Float32, 2, 1)), layer_2 = (weight = rand(Float32, 2, 2), bias = rand(Float32, 2, 1)))
+    tunables, repack, aliases = canonicalize(Tunable(), test_p)
+    @test test_p == repack(tunables)
+    @test length(tunables) == 4 + 2 + 4 + 2
+    @test tunables isa AbstractVector
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Motivated by https://github.com/SciML/SciMLSensitivity.jl/pull/1057#issuecomment-2158114277 and following https://github.com/SciML/SciMLSensitivity.jl/pull/1057#issuecomment-2158144762 this PR allows passing NamedTuples as SciMLStructures by assuming a NamedTuple is comprised only of Arrays and the full NT counts as Tunable.

Add any other context about the problem here.
