### PR TITLE
chore: replace `convert` with `ArrayInterface.restructure`

### DIFF
--- a/src/SciMLStructures.jl
+++ b/src/SciMLStructures.jl
@@ -1,6 +1,6 @@
 module SciMLStructures
 
-using ArrayInterface: has_trivial_array_constructor
+using ArrayInterface: has_trivial_array_constructor, restructure
 
 include("interface.jl")
 include("array.jl")

--- a/src/array.jl
+++ b/src/array.jl
@@ -3,21 +3,19 @@ hasportion(::Constants, ::AbstractArray) = false
 hasportion(::Caches, ::AbstractArray) = false
 hasportion(::Discrete, ::AbstractArray) = false
 
-struct ArrayRepack{T, Ty}
-    sz::T
-    type::Ty
+struct ArrayRepack{T}
+    x::T
 end
 function (f::ArrayRepack)(A)
-    @assert length(A) == prod(f.sz)
-    A_ = if has_trivial_array_constructor(f.type, A)
-        convert(f.type, A)
+    @assert length(A) == prod(size(f.x))
+    if has_trivial_array_constructor(f.type, A)
+        restructure(f.x, A)
     else
-        error("The original type $(typeof(f.type)) does not support the SciMLStructures interface via the AbstractArray `repack` rules. No method exists to take in a regular array and construct the parent type back. Please define the SciMLStructures interface for this type.")
+        error("The original type $(typeof(f.x)) does not support the SciMLStructures interface via the AbstractArray `repack` rules. No method exists to take in a regular array and construct the parent type back. Please define the SciMLStructures interface for this type.")
     end
-    reshape(A_, f.sz)
 end
 
-canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(size(p), typeof(p)), true
+canonicalize(::Tunable, p::AbstractArray) = vec(p), ArrayRepack(p), true
 canonicalize(::Constants, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Caches, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Discrete, p::AbstractArray) = nothing, nothing, nothing


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

`restructure` handles `convert` calls more gracefully. It should also help with https://github.com/SciML/SciMLSensitivity.jl/actions/runs/9700693333/job/26772687124?pr=1057

Add any other context about the problem here.
