### PR TITLE
HOTFIX: correctly pick the type for ArrayRepack

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -8,7 +8,7 @@ struct ArrayRepack{T}
 end
 function (f::ArrayRepack)(A)
     @assert length(A) == prod(size(f.x))
-    if has_trivial_array_constructor(f.type, A)
+    if has_trivial_array_constructor(typeof(f.x), A)
         restructure(f.x, A)
     else
         error("The original type $(typeof(f.x)) does not support the SciMLStructures interface via the AbstractArray `repack` rules. No method exists to take in a regular array and construct the parent type back. Please define the SciMLStructures interface for this type.")


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This is a hotfix for the missed change. `f.type -> typeof(f.x)`

Add any other context about the problem here.
