### PR TITLE
chore: mark only dense arrays as SciMLStructure

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -20,7 +20,8 @@ canonicalize(::Constants, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Caches, p::AbstractArray) = nothing, nothing, nothing
 canonicalize(::Discrete, p::AbstractArray) = nothing, nothing, nothing
 
-isscimlstructure(::AbstractArray) = true
+isscimlstructure(::AbstractArray) = false
+isscimlstructure(::AbstractArray{<:Number}) = true
 
 function SciMLStructures.replace(
         ::SciMLStructures.Tunable, arr::AbstractArray, new_arr::AbstractArray)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Consider
```julia
p = [1., 2., [3,4,5], mystruct(6, -7), control::Function]
```
This isn't a SciMLStructure, however,

```julia-repl
julia> isscimlstructure(p)
true
```

Add any other context about the problem here.
