### PR TITLE
Solve newprob so that output actually depends on input

### DIFF
--- a/docs/src/example.md
+++ b/docs/src/example.md
@@ -51,7 +51,7 @@ function simulate_with_tunables(tunables)
   coeffs = reshape(tunables[6:end], size(p.coeffs))
   newp = Parameters(subpars, coeffs)
   newprob = remake(prob; p = newp)
-  sol = solve(prob, Tsit5())
+  sol = solve(newprob, Tsit5())
   return sum(sol.u[end])
 end
 ```


### PR DESCRIPTION
## Checklist

- [X] Appropriate tests were added
- [X] Any code changes were done in a way that does not break public API
- [X] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [X] Any new documentation only uses public API
  
## Additional context

Going through the new example, I saw that the gradient returned `(nothing,)`; checked with `ForwardDiff` and got all zeros; then just looked at the function value with different inputs, to see that it was indeed identical.  It's hard to see this kind of mistake, but the `newprob` was never actually used; it just re-solved the original problem every time.  With this change, I obtain consistent gradients with `Zygote`, `ForwardDiff`, and even `FiniteDiff`.