### PR TITLE
Bump version to 1.10.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLStructures"
 uuid = "53ae85a6-f571-4167-b2af-e1d143709226"
-version = "1.10.1"
+version = "1.10.2"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (1.10.1 -> 1.10.2) to release unreleased commits on `main` via JuliaRegistrator.