### PR TITLE
Document public API coverage

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Aqua = "0.8"
 ArrayInterface = "7.11"
 PrecompileTools = "1"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1, 2.1"
 Test = "1.10"
 julia = "1.10"
 
@@ -21,6 +21,9 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+SciMLTesting = {rev = "a5cecca928f2c684c23505c3cd83921d71753e2e", url = "https://github.com/SciML/SciMLTesting.jl"}
 
 [targets]
 test = ["Aqua", "Test", "SafeTestsets", "SciMLTesting"]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,5 +1,18 @@
 # API
 
-```@autodocs
-Modules = [SciMLStructures]
+```@docs
+SciMLStructures
+SciMLStructures.isscimlstructure
+SciMLStructures.ismutablescimlstructure
+SciMLStructures.hasportion
+SciMLStructures.canonicalize
+SciMLStructures.replace
+SciMLStructures.replace!
+SciMLStructures.AbstractPortion
+SciMLStructures.Tunable
+SciMLStructures.Constants
+SciMLStructures.Caches
+SciMLStructures.Discrete
+SciMLStructures.Initials
+SciMLStructures.Input
 ```

--- a/src/SciMLStructures.jl
+++ b/src/SciMLStructures.jl
@@ -1,3 +1,12 @@
+"""
+    SciMLStructures
+
+Interfaces for exposing structured non-state values to SciML solvers and tools.
+
+SciMLStructures defines portion tags such as [`Tunable`](@ref) and [`Constants`](@ref),
+along with [`canonicalize`](@ref), [`replace`](@ref), and [`replace!`](@ref)
+interfaces that custom parameter containers can implement.
+"""
 module SciMLStructures
 
 using ArrayInterface: has_trivial_array_constructor, restructure

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,13 +1,20 @@
 """
-Returns whether the object satisfies the SciMLStructure interface. Defaults to `false` and types
-are required to opt-into the interface.
+    isscimlstructure(p)::Bool
+
+Return whether `p` satisfies the SciMLStructures interface.
+
+The default is `false`; types opt in by defining `isscimlstructure(::MyType) = true`.
+`AbstractArray{<:Number}` is treated as a SciMLStructure by built-in methods.
 """
 isscimlstructure(p) = false
 
 """
-Returns whether the SciMLStructure object is mutable and thus compatible with the interface
-functions that require mutation. Note that this is not mutable in the sense of the Julia
-type, rather mutable in the sense of `AbstractPortion` replacement, i.e. `replace!`
+    ismutablescimlstructure(p)::Bool
+
+Return whether `p` supports the mutating SciMLStructures interface.
+
+This is not mutability in the sense of the Julia type. It means the structure supports
+in-place `AbstractPortion` replacement through [`replace!`](@ref).
 """
 function ismutablescimlstructure end
 
@@ -71,23 +78,31 @@ SciMLStructure. For more information on the arguments, see canonicalize.
 function replace! end
 
 """
-An AbstractPortion object to be used in the SciMLStructures.jl interfaces, i.e.
+    AbstractPortion
+
+An abstract portion tag used in the SciMLStructures.jl interfaces, i.e.
 `canonicalize(::AbstractPortion, p::T1)` or `replace!(::AbstractPortion, p::T1)`.
 """
 abstract type AbstractPortion end
 
 """
+    Tunable()
+
 The tunable portion of the SciMLStructure, i.e. the parameters which are meant to be optimized.
 """
 struct Tunable <: AbstractPortion end
 
 """
+    Constants()
+
 The constant portion of the SciMLStructure, i.e. the parameters which are meant to be
 constant with respect to optimization.
 """
 struct Constants <: AbstractPortion end
 
 """
+    Caches()
+
 The caches portion of the SciMLStructure, i.e. the caches which are meant to allow for
 writing the model function without allocations.
 
@@ -95,7 +110,7 @@ Rules for caches:
 
   - Caches should be a mutable object.
   - Caches should not assume any previous value in them. All values within the cache should be
-    written into in the `f` cal that it is used from.
+    written into in the `f` call that they are used from.
 
 For making caches compatible with automatic differentiation, see
 [PreallocationTools.jl](https://docs.sciml.ai/PreallocationTools/stable/).
@@ -103,16 +118,22 @@ For making caches compatible with automatic differentiation, see
 struct Caches <: AbstractPortion end
 
 """
+    Discrete()
+
 The discrete portion of the SciMLStructure.
 """
 struct Discrete <: AbstractPortion end
 
 """
+    Input()
+
 The inputs portion of the SciMLStructure.
 """
 struct Input <: AbstractPortion end
 
 """
+    Initials()
+
 The portion of the SciMLStructure used for parameters solely involved in initialization.
 These should be floating point numbers supporting automatic differentiation.
 """

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -1,4 +1,4 @@
-using PrecompileTools: @setup_workload, @compile_workload
+import PrecompileTools: @setup_workload, @compile_workload
 
 @setup_workload begin
     # Minimal setup - avoid heavy dependencies

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -8,12 +8,13 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
 SciMLStructures = {path = "../.."}
+SciMLTesting = {rev = "a5cecca928f2c684c23505c3cd83921d71753e2e", url = "https://github.com/SciML/SciMLTesting.jl"}
 
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 SafeTestsets = "0.0.1, 0.1, 1"
 SciMLStructures = "1"
-SciMLTesting = "1.7"
+SciMLTesting = "2.1"
 Test = "1.10"
 julia = "1.10"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLStructures = "53ae85a6-f571-4167-b2af-e1d143709226"
@@ -9,6 +10,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 SciMLStructures = {path = "../.."}
 
 [compat]
+Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 SafeTestsets = "0.0.1, 0.1, 1"
 SciMLStructures = "1"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -8,6 +8,7 @@ run_qa(
     # JET is exercised below as targeted `@test_opt` type-stability checks, not
     # `JET.test_package`; `using JET` would otherwise auto-enable the latter.
     jet = false,
+    api_docs_kwargs = (; rendered = true),
 )
 
 @testset "JET static analysis" begin


### PR DESCRIPTION
Draft PR. Please ignore until reviewed by @ChrisRackauckas.

## Summary

- Add a module docstring and signature-style docstrings for public SciMLStructures interface bindings that lacked explicit signature headers.
- Replace the broad API `@autodocs` block with an explicit `@docs` block covering every Julia `public` binding.
- Enable SciMLTesting's public API docs QA check with `api_docs_kwargs = (; rendered = true)`.
- Pin both the root test environment and the QA environment to SciMLTesting v2.1 from `SciML/SciMLTesting.jl` commit `a5cecca928f2c684c23505c3cd83921d71753e2e`, because the helper is not registered in General yet. Root compat remains `1, 2.1` so lts Core jobs can still resolve registered SciMLTesting 1.x.
- Keep `Aqua` as a direct QA dependency because Aqua's ambiguity child process requires it in the active QA project.

## Validation

- `git diff --check`
- Runic.jl check passed for `src/SciMLStructures.jl`, `src/interface.jl`, `src/precompilation.jl`, and `test/qa/qa.jl`.
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.12 --project=test/qa -e 'using Pkg; Pkg.instantiate(); include("test/qa/qa.jl")'` resolved SciMLTesting v2.1 from the pinned commit and passed QA: 19/19, including `Public API documentation`: 2/2, plus JET static analysis: 17/17.
- `timeout 3600 env GROUP=QA /home/crackauc/.juliaup/bin/julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` reproduced the CI QA path and passed: 36/36.
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'` passed Core tests: 16/16.
- Full `docs/make.jl` reached clean Documenter doc checks on the earlier final docs/source tree, but failed linkcheck on the existing ColPrac GitHub URL with HTTP 429. The same docs pages rendered successfully with `linkcheck=false`. The later follow-ups changed only QA/test environment files.