### PR TITLE
Use SciMLTesting v2.1 test runner

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Aqua = "0.8"
 ArrayInterface = "7.11"
 PrecompileTools = "1"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1, 2.1"
+SciMLTesting = "2.1"
 Test = "1.10"
 julia = "1.10"
 
@@ -21,9 +21,6 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[sources]
-SciMLTesting = {rev = "a5cecca928f2c684c23505c3cd83921d71753e2e", url = "https://github.com/SciML/SciMLTesting.jl"}
 
 [targets]
 test = ["Aqua", "Test", "SafeTestsets", "SciMLTesting"]

--- a/test/Core/Project.toml
+++ b/test/Core/Project.toml
@@ -5,9 +5,6 @@ SciMLStructures = "53ae85a6-f571-4167-b2af-e1d143709226"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-SciMLStructures = {path = "../.."}
-
 [compat]
 AllocCheck = "0.1, 0.2"
 SafeTestsets = "0.0.1, 0.1, 1"

--- a/test/Core/Project.toml
+++ b/test/Core/Project.toml
@@ -12,5 +12,5 @@ SciMLStructures = {path = "../.."}
 AllocCheck = "0.1, 0.2"
 SafeTestsets = "0.0.1, 0.1, 1"
 SciMLStructures = "1"
-SciMLTesting = "1"
+SciMLTesting = "2.1"
 Test = "1.10"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,9 +6,6 @@ SciMLStructures = "53ae85a6-f571-4167-b2af-e1d143709226"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-SciMLStructures = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -8,7 +8,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
 SciMLStructures = {path = "../.."}
-SciMLTesting = {rev = "a5cecca928f2c684c23505c3cd83921d71753e2e", url = "https://github.com/SciML/SciMLTesting.jl"}
 
 [compat]
 Aqua = "0.8"


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- require SciMLTesting v2.1 in root and Core test environments
- remove temporary SciMLTesting URL/rev source pins now that v2.1 is released
- keep the existing public API docs QA coverage intact

## Validation
- `timeout 3600 julia --project=. -e 'using Pkg; Pkg.test()'`\n- `JULIA_PKG_SERVER='\ GROUP=QA timeout 3600 julia --project=. -e 'using Pkg; Pkg.test()'`\n- `git diff --check`\n- `julia --project=. -e 'using TOML; foreach(TOML.parsefile, filter(isfile, ["Project.toml", "test/Project.toml", "test/qa/Project.toml", "test/Core/Project.toml"]))'`\n- `julia -m Runic --check test/runtests.jl`