### PR TITLE
Release prep: bump SciMLStructures to 1.10.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLStructures"
 uuid = "53ae85a6-f571-4167-b2af-e1d143709226"
-version = "1.10.2"
+version = "1.10.3"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Patch release for the accumulated docstring/QA/test-scaffolding changes since 1.10.2 (no functional/behavioral changes).