### PR TITLE
Document and test the SciMLStructures extension interface

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,7 +16,6 @@ makedocs(
     modules = [SciMLStructures],
     sitename = "SciMLStructures.jl",
     clean = true,
-    doctest = false,
     linkcheck = true,
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],

--- a/docs/src/example.md
+++ b/docs/src/example.md
@@ -108,7 +108,7 @@ function SS.replace!(::SS.Tunable, p::Parameters, newbuffer)
         subpar.p = val
     end
     copyto!(p.coeffs, view(newbuffer, (length(p.subparams) + 1):length(newbuffer)))
-    return p
+    return nothing
 end
 ```
 
@@ -147,7 +147,7 @@ function SS.replace!(::SS.Constants, p::Parameters, newbuffer)
         p.subparams[i].q = newbuffer[2i - 1]
         p.subparams[i].r = newbuffer[2i]
     end
-    return p
+    return nothing
 end
 
 buf, repack, alias = SS.canonicalize(SS.Constants(), p)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,38 +1,91 @@
 """
     isscimlstructure(p)::Bool
 
-Return whether `p` satisfies the SciMLStructures interface.
+Return whether `p` implements the SciMLStructures interface.
 
-The default is `false`; types opt in by defining `isscimlstructure(::MyType) = true`.
-`AbstractArray{<:Number}` is treated as a SciMLStructure by built-in methods.
+# Arguments
+
+  - `p`: The value to classify.
+
+# Interface
+
+The fallback returns `false`. A custom container opts in by defining
+`isscimlstructure(::MyType) = true`, then implementing the portion methods it supports.
+`AbstractArray{<:Number}` opts in through built-in methods.
+
+# Examples
+
+```jldoctest
+julia> using SciMLStructures
+
+julia> SciMLStructures.isscimlstructure([1.0, 2.0])
+true
+```
 """
 isscimlstructure(p) = false
 
 """
     ismutablescimlstructure(p)::Bool
 
-Return whether `p` supports the mutating SciMLStructures interface.
+Return whether `p` supports in-place replacement for its implemented portions.
 
-This is not mutability in the sense of the Julia type. It means the structure supports
-in-place `AbstractPortion` replacement through [`replace!`](@ref).
+# Arguments
+
+  - `p`: A SciML structure value.
+
+# Interface
+
+Define `ismutablescimlstructure(::MyType) = true` only when
+[`replace!`](@ref) is implemented for every portion reported by [`hasportion`](@ref).
+This trait describes the SciMLStructures replacement contract, rather than merely
+whether the Julia type is mutable.
 """
 function ismutablescimlstructure end
 
 """
     hasportion(::AbstractPortion, p)::Bool
 
-Denotes whether a portion is used in a given definition of a SciMLStructure. If `false`,
-then it's expected that the canonical values are `nothing`.
+Return whether `p` contains the requested SciML structure `portion`.
+
+# Arguments
+
+  - `portion`: A tag such as [`Tunable`](@ref), [`Constants`](@ref), or [`Caches`](@ref).
+  - `p`: A SciML structure value.
+
+# Interface
+
+Implement this for every supported `AbstractPortion` and return `false` for absent
+portions. An absent portion must have `canonicalize(portion, p) == (nothing, nothing,
+nothing)`.
 """
 function hasportion end
 
 """
     canonicalize(::AbstractPortion, p::T1) -> values::T2, repack, aliases::Bool
 
-The core function of the interface is the `canonicalize` function. `canonicalize` allows the user to define
-to the solver how to represent the given "portion" in a standard `AbstractVector` type which allows for
-interfacing with standard tools like linear algebra in an efficient manner. The type of portions which
-are defined are:
+Convert one `portion` of `p` to its canonical vector representation.
+
+# Arguments
+
+  - `portion`: The requested [`AbstractPortion`](@ref).
+  - `p`: A SciML structure value.
+
+# Returns
+
+A three-tuple `(values, repack, aliases)`:
+
+  - `values`: The canonical vector representation, or `nothing` when the portion is absent.
+  - `repack`: A callable accepting values in the same ordering and returning a new value
+    of `typeof(p)`, or `nothing` when the portion is absent.
+  - `aliases`: Whether mutating `values` may mutate `p`, or `nothing` when the portion
+    is absent.
+
+# Interface
+
+Implement this for each portion where [`hasportion`](@ref) returns `true`. `values` must
+be an `AbstractVector`; flatten multidimensional values in a stable ordering. `repack`
+and [`replace`](@ref) must interpret replacement values in that same ordering. The
+defined portions are:
 
   - Tunable: the tunable values/parameters, i.e. the values of the structure which are supposed to be considered
     non-constant when used in the context of an inverse problem solve. For example, this is the set of
@@ -62,18 +115,36 @@ function canonicalize end
 """
     replace(::AbstractPortion, p::T1, new_values) -> p::T1
 
-Equivalent to `canonicalize(::AbstractPortion, p::T1)[2](new_values)`, though allowed to
-optimize and not construct intermediates. For more information on the arguments, see
-canonicalize.
+Return a copy of `p` with one `portion` replaced by `new_values`.
+
+# Arguments
+
+  - `portion`: The portion to replace.
+  - `p`: A SciML structure value.
+  - `new_values`: Values in the ordering returned by `canonicalize(portion, p)`.
+
+# Interface
+
+This must be observationally equivalent to `canonicalize(portion, p)[2](new_values)`.
+Implementations may avoid intermediate canonical buffers.
 """
 function replace end
 
 """
     replace!(::AbstractPortion, p::T1, new_values)::Nothing
 
-Equivalent to `canonicalize(::AbstractPortion, p::T1)[2](new_values)`, though done in a mutating
-fashion and is allowed to optimize and not construct intermediates. Requires a mutable
-SciMLStructure. For more information on the arguments, see canonicalize.
+Replace one `portion` of `p` in place with `new_values`.
+
+# Arguments
+
+  - `portion`: The portion to replace.
+  - `p`: A mutable SciML structure value.
+  - `new_values`: Values in the ordering returned by `canonicalize(portion, p)`.
+
+# Interface
+
+Define this only when [`ismutablescimlstructure`](@ref) returns `true`. It must mutate
+`p`, return `nothing`, and produce the same resulting values as [`replace`](@ref).
 """
 function replace! end
 

--- a/test/Core/alloc_tests.jl
+++ b/test/Core/alloc_tests.jl
@@ -1,6 +1,6 @@
 using SciMLStructures
 using SciMLStructures: Tunable, Constants, Caches, Discrete, Initials, Input,
-    canonicalize, hasportion, isscimlstructure
+    canonicalize, hasportion, ismutablescimlstructure, isscimlstructure, replace, replace!
 using AllocCheck
 using Test
 
@@ -97,4 +97,79 @@ const SKIP_ALLOCCHECK = Sys.isapple() && Sys.ARCH == :aarch64 && VERSION >= v"1.
             @test check_canon_input(arr) == (nothing, nothing, nothing)
         end
     end
+end
+
+@testset "Generic SciMLStructures interface" begin
+    mutable struct GenericParameters
+        tunables::Vector{Float64}
+        constant::Float64
+    end
+
+    isscimlstructure(::GenericParameters) = true
+    ismutablescimlstructure(::GenericParameters) = true
+    hasportion(::Tunable, ::GenericParameters) = true
+    hasportion(::Constants, ::GenericParameters) = true
+    hasportion(::Union{Caches, Discrete, Initials, Input}, ::GenericParameters) = false
+
+    function canonicalize(::Tunable, p::GenericParameters)
+        values = copy(p.tunables)
+        repack = values -> GenericParameters(collect(values), p.constant)
+        return values, repack, false
+    end
+    function canonicalize(::Constants, p::GenericParameters)
+        values = [p.constant]
+        repack = values -> GenericParameters(copy(p.tunables), only(values))
+        return values, repack, false
+    end
+    canonicalize(::Union{Caches, Discrete, Initials, Input}, ::GenericParameters) =
+        (nothing, nothing, nothing)
+
+    function replace(::Tunable, p::GenericParameters, values)
+        return GenericParameters(collect(values), p.constant)
+    end
+    function replace(::Constants, p::GenericParameters, values)
+        return GenericParameters(copy(p.tunables), only(values))
+    end
+    function replace!(::Tunable, p::GenericParameters, values)
+        copyto!(p.tunables, values)
+        return nothing
+    end
+    function replace!(::Constants, p::GenericParameters, values)
+        p.constant = only(values)
+        return nothing
+    end
+
+    p = GenericParameters([1.0, 2.0], 3.0)
+    @test isscimlstructure(p)
+    @test ismutablescimlstructure(p)
+    @test hasportion(Tunable(), p)
+    @test hasportion(Constants(), p)
+    for portion in (Caches(), Discrete(), Initials(), Input())
+        @test !hasportion(portion, p)
+        @test canonicalize(portion, p) == (nothing, nothing, nothing)
+    end
+
+    tunables, repack_tunables, aliases = canonicalize(Tunable(), p)
+    @test tunables == [1.0, 2.0]
+    @test !aliases
+    rebuilt_tunables = repack_tunables([4.0, 5.0])
+    replaced_tunables = replace(Tunable(), p, [4.0, 5.0])
+    @test rebuilt_tunables.tunables == [4.0, 5.0]
+    @test rebuilt_tunables.constant == 3.0
+    @test replaced_tunables.tunables == rebuilt_tunables.tunables
+    @test replaced_tunables.constant == rebuilt_tunables.constant
+
+    constants, repack_constants, aliases = canonicalize(Constants(), p)
+    @test constants == [3.0]
+    @test !aliases
+    rebuilt_constants = repack_constants([6.0])
+    replaced_constants = replace(Constants(), p, [6.0])
+    @test rebuilt_constants.tunables == [1.0, 2.0]
+    @test rebuilt_constants.constant == 6.0
+    @test replaced_constants.tunables == rebuilt_constants.tunables
+    @test replaced_constants.constant == rebuilt_constants.constant
+    @test replace!(Tunable(), p, [7.0, 8.0]) === nothing
+    @test p.tunables == [7.0, 8.0]
+    @test replace!(Constants(), p, [9.0]) === nothing
+    @test p.constant == 9.0
 end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -4,11 +4,9 @@ using SciMLStructures: Tunable, Constants, Caches, Discrete, Initials, Input,
 
 run_qa(
     SciMLStructures;
-    explicit_imports = true,
     # JET is exercised below as targeted `@test_opt` type-stability checks, not
     # `JET.test_package`; `using JET` would otherwise auto-enable the latter.
     jet = false,
-    api_docs_kwargs = (; rendered = true),
 )
 
 @testset "JET static analysis" begin


### PR DESCRIPTION
## Summary
- document the public SciMLStructures extension contract with argument, return, and ownership rules
- add an independent generic mutable-container contract test
- require SciMLTesting 2.1+ across root and isolated test environments, removing stale source pins and redundant QA overrides
- enable documentation doctests and align `replace!` examples with its `Nothing` contract

## Verification
- `julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`\n- `julia +1.12 --project=docs -e 'using Pkg; Pkg.develop(path = pwd()); Pkg.instantiate(); include("docs/make.jl")'`\n- `julia +1.10 --project=. -e 'using Runic; exit(Runic.main(["--check", "src", "test", "docs"]))'`\n\nPlease ignore until reviewed by @ChrisRackauckas.