### PR TITLE
Bump SciMLStructures to v1.10.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLStructures"
 uuid = "53ae85a6-f571-4167-b2af-e1d143709226"
-version = "1.10.3"
+version = "1.10.4"
 authors = ["SciML"]
 
 [deps]
@@ -24,3 +24,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Aqua", "Test", "SafeTestsets", "SciMLTesting"]
+


### PR DESCRIPTION
Bumps `SciMLStructures` **v1.10.3 → v1.10.4** (patch) so the accumulated unreleased source changes on the default branch can be registered.

**What changed since v1.10.3:** docstring / public-API documentation additions and migration of QA to SciMLTesting 2.4. No public API additions/removals and no behavioral changes were found in the diff, so this is a patch release.

Part of a sweep of SciML packages whose `src/` had changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)